### PR TITLE
Added support for query params

### DIFF
--- a/src/signalr-core.common.ts
+++ b/src/signalr-core.common.ts
@@ -36,11 +36,19 @@ export class Common extends Observable {
 
     return new Promise((resolve, reject) => {
       const run = () => {
+        let queryString = "?";
+        let idParam = "id=";
+        let urlPieces = httpURL.split("?");
+        if (urlPieces.length > 1) {
+          queryString += urlPieces[1];
+          httpURL = urlPieces[0];
+          idParam = "&" + idParam;
+        }
         this.socketUrl = httpURL.replace(/(http)(s)?\:\/\//, 'ws$2://');
-        this.socketUrl += '?id=';
+        this.socketUrl += queryString + idParam;
         const self = this;
         // @ts-ignore
-        this.makeRequest(header, 'POST', `${httpURL}/negotiate`, (err, data) => {
+        this.makeRequest(header, 'POST', `${httpURL}/negotiate` + queryString, (err, data) => {
           this.setStatus({id: 0, name: 'Start negotiate'});
           if (err) {
             reject(err);


### PR DESCRIPTION
## What is the current behavior?
If we have a query parameter on the original url then the negotiate is added to the end of that string.
eg. http://localhost:5060/hub?token=<some-token> becomes http://localhost:5060/hub?token=<some-token>/negotiate

## What is the new behavior?
The query parameter is separated from the url until the final url is built, and then added to the end of it.
eg. http://localhost:5060/hub?token=<some-token> becomes http://localhost:5060/hub/negotiate?token=<some-token>


This is required in some cases where the Authorization header alone won't work. See this section 

>  Note
> 
> The query string is used on browsers when connecting with WebSockets and Server-Sent Events due to browser API limitations. When using HTTPS, query string values are secured by the TLS connection. However, many servers log query string values. For more information, see Security considerations in ASP.NET Core SignalR. SignalR uses headers to transmit tokens in environments which support them (such as the .NET and Java clients).

on this page [(https://docs.microsoft.com/en-us/aspnet/core/signalr/authn-and-authz?view=aspnetcore-3.1)]





